### PR TITLE
More corrections

### DIFF
--- a/std/math.d
+++ b/std/math.d
@@ -4571,3 +4571,11 @@ unittest
     real r = tan(-2.0L);
     assert(fabs(r - 2.18504f) < .00001);
 }
+
+/// Returns true if i is a power of two and false otherwise.
+bool isPow2(I)(I i)
+if(isIntegral!I)
+{ 
+    return i && !(i & (i - 1)); 
+}
+


### PR DESCRIPTION
Renamed `isPowerOfTwo` to `isPow2`, moved it to `std.math` and made it public. It only works for integers, but it would probably make sense to add a floating point version later.

Renamed `fastUniformFloat` to `uniform01` and made it public. Also fixed a bug in it - now it always returns less than one.
